### PR TITLE
Unit test update for R v3.6 and less

### DIFF
--- a/tests/testthat/test-complete_ae_data.R
+++ b/tests/testthat/test-complete_ae_data.R
@@ -10,7 +10,7 @@ test_that("multiplication works", {
 
 
   id_df1_correct <-
-    data.frame(
+    tibble::tibble(
       patient_id = paste0("ID", 1:5),
       trt = c(rep("A", 3),rep("B", 2))
     )

--- a/tests/testthat/test-get_unique.R
+++ b/tests/testthat/test-get_unique.R
@@ -1,5 +1,5 @@
 test_that("get_unique() returns correct output", {
-  dat <- data.frame(
+  dat <- tibble::tibble(
     w = c(NA, 1, "B"),
     x = c(1, 1, 2),
     y = c("B", "B", "A"),


### PR DESCRIPTION
In R 4.0, they changed the strings as factors default to FALSE. This was causing issues for the unit tests on old R builds. In the recent builds, variables created in `data.frame()` were not factors, but in old R builds defaulted to factor that led to failing tests. 

![image](https://user-images.githubusercontent.com/26774684/146678962-37a341ad-9c14-453b-9da1-35b8b51a76a6.png)
