### PR TITLE
Updated `tbl_adverse_event()` to use `.complete_ae_data()`

### DIFF
--- a/R/complete_ae_data.R
+++ b/R/complete_ae_data.R
@@ -159,33 +159,25 @@
       )
   }
 
-
-  # create tabulate vars vector ------------------------------------------------
-  # maybe you have a slicker way of doing this?
-  # please review this carefully, not sure this is doing what is intended
-
-  # only id and ae required
-  tab_vars <- c("id", "ae")
-
-  # add in other variables when present
-  if (!is.null(strata)) { tab_vars <- c(tab_vars, "strata") }
-  if (!is.null(soc))    { tab_vars <- c(tab_vars, "soc") }
-  if (!is.null(by))     { tab_vars <- c(tab_vars, "by") }
-
-
   # identifying rows that will be used in tabulation ---------------------------
- data_full <-
+  if (!is.null(soc)) {
+    data_full <-
+      data_full %>%
+      arrange(across(any_of(c("id", "strata", "soc", "by")))) %>%
+      group_by(across(any_of(c("id", "strata", "soc")))) %>%
+      mutate(
+        ..soc.. = dplyr::row_number() == dplyr::n()
+      ) %>%
+      ungroup()
+  }
+  data_full <-
     data_full %>%
-    arrange(across(any_of(tab_vars))) %>%
-    group_by(across(any_of(tab_vars))) %>%
-    # i dropped soc here, so maybe i made this more trouble than it is worth?
-    # but i think there is a possible solution with mutate across and walrus
-    # operator
+    arrange(across(any_of(c("id", "strata", "soc", "ae", "by")))) %>%
+    group_by(across(any_of(c("id", "strata", "soc", "ae")))) %>%
     mutate(
       ..ae.. = dplyr::row_number() == dplyr::n()
     ) %>%
     ungroup()
-
 
   return(data_full)
 }

--- a/R/tbl_adverse_events.R
+++ b/R/tbl_adverse_events.R
@@ -1,5 +1,15 @@
 #' Tabulate Adverse Events
 #'
+#' @description
+#' The function tabulates adverse events. One AE per ID will be counted in the
+#' resulting table. If a `by=` variable is passed and a
+#' patient experienced more than one of the same AE, the AE associated with the
+#' highest `by=` level will be included. For example, if a patient has two of
+#' the same AE and `by = grade`, the AE with the highest grade will be
+#' included.
+#' Similarly, if tabulations within system organ class are requested, the
+#' AE within SOC associated with the highest grade will be tabulated.
+#'
 #' @param data Data frame
 #' @param id Variable name of the patient ID
 #' @param soc Variable name of the system organ class column
@@ -14,6 +24,7 @@
 #'
 #' @export
 #' @examples
+#' # Example 1 -----------------------------------------------------------------
 #' df_adverse_events %>%
 #'   tbl_adverse_events(
 #'     id = patient_id,
@@ -23,7 +34,17 @@
 #'     strata = trt,
 #'     header = "**Grade {level}**"
 #'   ) %>%
-#'   as_kable() # UPDATE THIS WITH PROPER gt image at some point..
+#'   as_kable() # UPDATE THIS WITH PROPER gt image at some point.
+#'
+#' # Example 2 -----------------------------------------------------------------
+#' df_adverse_events %>%
+#'   tbl_adverse_events(
+#'     id = patient_id,
+#'     ae = adverse_event,
+#'     by = grade,
+#'     header = "**Grade {level}**"
+#'   ) %>%
+#'   as_kable() # UPDATE THIS WITH PROPER gt image at some point.
 
 tbl_adverse_events <- function(data, id, ae,
                                soc = NULL, by = NULL, strata = NULL,

--- a/R/tbl_adverse_events.R
+++ b/R/tbl_adverse_events.R
@@ -3,14 +3,14 @@
 #' @param data Data frame
 #' @param id Variable name of the patient ID
 #' @param soc Variable name of the system organ class column
-#' @param adverse_event Variable name of the adverse event column
-#' @param grade Variable to split results by, e.g. report AEs by grade
+#' @param ae Variable name of the adverse event column
+#' @param by Variable to split results by, e.g. report AEs by grade
 #' @param strata Variable to stratify results by, e.g. report AEs summaries
 #' by treatment group
 #' @param statistic String indicating the statistics that will be reported.
 #' The default is `"{n} ({p})"`
 #' @param header String indicating the header to be placed in the table.
-#' Default is `"**Grade {level}**"`
+#' Default is `"**{level}**"`
 #'
 #' @export
 #' @examples
@@ -24,29 +24,33 @@
 #'   ) %>%
 #'   as_kable() # UPDATE THIS WITH PROPER gt image at some point..
 
-tbl_adverse_events <- function(data, id, adverse_event, soc,
-                               grade, strata, statistic = "{n} ({p})",
-                               header = "**Grade {level}**") {
+tbl_adverse_events <- function(data, id, ae,
+                               soc = NULL, by = NULL, strata = NULL,
+                               statistic = "{n} ({p})",
+                               header = "**{level}**") {
   # evaluate bare selectors/check inputs ---------------------------------------
   stopifnot(inherits(data, "data.frame"))
   id <-
     .select_to_varnames({{ id }}, data = data,
                         arg_name = "id", select_single = TRUE)
-  adverse_event <-
-    .select_to_varnames({{ adverse_event }}, data = data,
-                        arg_name = "adverse_event", select_single = TRUE)
+  ae <-
+    .select_to_varnames({{ ae }}, data = data,
+                        arg_name = "ae", select_single = TRUE)
   soc <-
     .select_to_varnames({{ soc }}, data = data,
                         arg_name = "soc", select_single = TRUE)
-  grade <-
-    .select_to_varnames({{ grade }}, data = data,
-                        arg_name = "grade", select_single = TRUE)
+  by <-
+    .select_to_varnames({{ by }}, data = data,
+                        arg_name = "by", select_single = TRUE)
   strata <-
     .select_to_varnames({{ strata }}, data = data,
                         arg_name = "strata", select_single = TRUE)
 
   # will return inputs ---------------------------------------------------------
   tbl_adverse_events_inputs <- as.list(environment())
+
+  .complete_ae_data(data, id = id, ae = ae, soc = soc, by = by, strata = strata,
+                    id_df = NULL, by_values = NULL)
 
   # create data frame where every AE is observed -------------------------------
   lst_name_recode <- list(id = id, adverse_event = adverse_event, soc = soc,

--- a/R/tbl_adverse_events.R
+++ b/R/tbl_adverse_events.R
@@ -17,10 +17,11 @@
 #' df_adverse_events %>%
 #'   tbl_adverse_events(
 #'     id = patient_id,
-#'     adverse_event = adverse_event,
+#'     ae = adverse_event,
 #'     soc = system_organ_class,
-#'     grade = grade,
-#'     strata = trt
+#'     by = grade,
+#'     strata = trt,
+#'     header = "**Grade {level}**"
 #'   ) %>%
 #'   as_kable() # UPDATE THIS WITH PROPER gt image at some point..
 
@@ -49,116 +50,151 @@ tbl_adverse_events <- function(data, id, ae,
   # will return inputs ---------------------------------------------------------
   tbl_adverse_events_inputs <- as.list(environment())
 
-  .complete_ae_data(data, id = id, ae = ae, soc = soc, by = by, strata = strata,
-                    id_df = NULL, by_values = NULL)
-
-  # create data frame where every AE is observed -------------------------------
-  lst_name_recode <- list(id = id, adverse_event = adverse_event, soc = soc,
-                          grade = grade, strata = strata)
+  # obtain the complete data ---------------------------------------------------
   data_complete <-
-    dplyr::rename(data, !!!lst_name_recode) %>%
-    dplyr::select(all_of(names(lst_name_recode))) %>%
-    tidyr::complete(
-      tidyr::nesting(id, strata), tidyr::nesting(soc, adverse_event),
-      fill = list(grade = 0)
-    ) %>%
-    mutate(grade = factor(grade, levels = 0:5))
+    .complete_ae_data(data, id = id, ae = ae, soc = soc, by = by,
+                      strata = strata, id_df = NULL, by_values = NULL) %>%
+    group_by(across(any_of("soc")))
+
+  # putting data into list of tibbles...one element per SOC --------------------
+  lst_data_complete <-
+    data_complete %>%
+    dplyr::group_split() %>%
+    rlang::set_names(dplyr::group_keys(data_complete) %>% purrr::pluck(1))
+
+  # tablulate SOC --------------------------------------------------------------
+  if (!is.null(soc)) {
+    lst_tbl_soc <-
+      purrr::imap(
+        lst_data_complete,
+        function(df_soc, soc) {
+          # keep observation that will be tabulated
+          df_soc <- filter(df_soc, .data$..soc..)
+
+          fn_tbl_soc <-
+            purrr::partial(fn_tbl,
+                           variable = "..soc..",
+                           label = soc,
+                           statistic = statistic,
+                           header = header,
+                           remove_header_row = FALSE,
+                           zero_symbol = NULL)
+
+          if ("strata" %in% names(df_soc)) {
+            tbl <-
+              gtsummary::tbl_strata(
+                data = df_soc,
+                strata = "strata",
+                .tbl_fun = ~fn_tbl_soc(data = .x)
+              )
+          }
+          else {
+            tbl <- fn_tbl_soc(data = df_soc)
+          }
+
+          tbl
+        }
+      )
+  }
 
   # tabulate AEs ---------------------------------------------------------------
-  df_results <-
-    data_complete %>%
-    tidyr::nest(data = -.data$soc) %>%
-    mutate(
-      # create a single line summary for each SOC
-      tbl_soc =
-        purrr::map2(
-          .data$soc, .data$data,
-          function(soc, df_soc) {
-            arrange(df_soc, .data$id, .data$grade) %>%
-              # keep highest `grade` value per patient, e.g. highest grade
-              group_by(.data$id) %>%
-              dplyr::slice_tail(n = 1) %>%
-              ungroup() %>%
-              # stratify summary table
-              gtsummary::tbl_strata(
-                strata = strata,
-                # create summary table
-                ~ .x %>%
-                  dplyr::select(.data$grade) %>%
-                  mutate(..all_true.. = TRUE) %>%
-                  gtsummary::tbl_summary(
-                    by = .data$grade,
-                    percent = "row",
-                    label = list(..all_true.. = soc),
-                    statistic = everything() ~ statistic
-                  ) %>%
-                  gtsummary::modify_header(
-                    gtsummary::all_stat_cols() ~ header) %>%
-                  # hide Grade 0 column
-                  gtsummary::modify_column_hide(all_of("stat_1"))
-              )
-          }
-        ),
-      # summarize each AE within SOC
-      tbl_ae =
-        purrr::map(
-          .data$data,
-          function(df_soc) {
-            arrange(df_soc, .data$id, .data$adverse_event, .data$grade) %>%
-              # keep highest `grade` value per patient per AE, e.g. highest grade
-              group_by(.data$id, .data$adverse_event) %>%
-              dplyr::slice_tail(n = 1) %>%
-              ungroup() %>%
-              gtsummary::tbl_strata(
-                strata = strata,
-                ~ .x %>%
-                  dplyr::select(.data$grade, .data$adverse_event) %>%
-                  gtsummary::tbl_summary(
-                    by = .data$grade,
-                    percent = "row",
-                    statistic = everything() ~ statistic
-                  ) %>%
-                  gtsummary::modify_header(
-                    gtsummary::all_stat_cols() ~ header) %>%
-                  gtsummary::remove_row_type(type = "header") %>%
-                  # hide Grade 0 column
-                  gtsummary::modify_column_hide(all_of("stat_1"))
-              )
-          }
-        ),
-      # stack SOC and AE tables
-      tbl = purrr::map2(.data$tbl_soc, .data$tbl_ae, ~gtsummary::tbl_stack(list(.x, .y)))
+  lst_tbl_ae <-
+    purrr::map(
+      lst_data_complete,
+      function(df_ae) {
+        # keep observation that will be tabulated
+        df_ae <- filter(df_ae, .data$..ae..)
+
+        fn_tbl_ae <-
+          purrr::partial(fn_tbl,
+                         variable = "ae",
+                         statistic = statistic,
+                         header = header,
+                         remove_header_row = TRUE,
+                         zero_symbol = NULL)
+
+        if ("strata" %in% names(df_ae)) {
+          tbl <-
+            gtsummary::tbl_strata(
+              data = df_ae,
+              strata = "strata",
+              .tbl_fun = ~fn_tbl_ae(data = .x)
+            )
+        }
+        else {
+          tbl <- fn_tbl_ae(data = df_ae)
+        }
+
+        tbl
+      }
     )
 
-  # stack all tbls and return --------------------------------------------------
-  # save a copy of what a zero count cell looks like, so we can make them missing
-  zero_count_statistic <-
-    stringr::str_glue_data(
-      .x = list(n = 0, p = 0, N = NA, N_obs = NA, N_miss = NA, N_nonmiss = NA,
-                p_miss = NA, p_nonmiss = NA),
-      statistic
-    )
+  # stacking tbls into big final AE table --------------------------------------
+  if (!is.null(soc)) {
+    tbl_final <-
+      # stack SOC with AEs within that SOC, then stack all tbls
+      purrr::map2(lst_tbl_soc, lst_tbl_ae,
+                  ~gtsummary::tbl_stack(list(.x, .y), quiet = TRUE)) %>%
+      gtsummary::tbl_stack(quiet = TRUE)
+  }
+  else {
+    tbl_final <-
+      gtsummary::tbl_stack(lst_tbl_ae, quiet = TRUE) %>%
+      # remove indentation for AEs
+      gtsummary::modify_table_styling(
+        columns = "label",
+        text_format = "indent",
+        undo_text_format = TRUE
+      )
+  }
 
-  # stack all the SOC/AE summary tables
-  df_results$tbl %>%
-    gtsummary::tbl_stack() %>%
-    # change zero count cells to em-dash
-    gtsummary::modify_table_body(
-      ~ .x %>%
-        mutate(across(gtsummary::all_stat_cols(),
-                                    ~ifelse(. == zero_count_statistic, NA_character_, .)))
-    ) %>%
-    gtsummary::modify_table_styling(
-      columns = gtsummary::all_stat_cols(),
-      rows = !is.na(.data$label),
-      missing_symbol = "\U2014"
-    ) %>%
+  # return final tbl -----------------------------------------------------------
+  tbl_final %>%
     # update labels
     gtsummary::modify_header(label = "**Adverse Event**") %>%
     # removing the no longer needed data elements saved in the individual stacked/merged tbls
     gtsummary::tbl_butcher() %>%
-    # return list with function's inputs
-    purrr::list_modify(inputs = tbl_adverse_events_inputs) %>%
+    # return list with function's inputs and the complete data
+    purrr::list_modify(inputs = tbl_adverse_events_inputs,
+                       data_complete = dplyr::ungroup(data_complete)) %>%
     # add class
     structure(class = c("tbl_adverse_events", "gtsummary"))
+}
+
+
+# define `tbl_summary()` function to tabulate SOC/AE
+fn_tbl <- function(data, variable, label = NULL, statistic, header,
+                   remove_header_row, zero_symbol = NULL) {
+  tbl <-
+    gtsummary::tbl_summary(
+      data = data,
+      by = "by",
+      percent = "row",
+      label = switch(!is.null(label), everything() ~ label),
+      statistic = everything() ~ statistic,
+      include = all_of(variable)
+    ) %>%
+    gtsummary::modify_header(gtsummary::all_stat_cols() ~ header)
+
+  # hide the column for unobserved data
+  column_to_hide <-
+    tbl$df_by %>%
+    filter(.data$by %in% "NOT OBSERVED") %>%
+    purrr::pluck("by_col")
+  if (!is.null(column_to_hide)) {
+    tbl <- gtsummary::modify_column_hide(tbl, columns = column_to_hide)
+  }
+
+  # remove the header row
+  if (isTRUE(remove_header_row)) {
+    tbl <- gtsummary::remove_row_type(tbl)
+  }
+
+  if (!is.null(zero_symbol)) {
+    # TODO: Add code to make zero count cells NA,
+    # then use `modify_table_styling()` to make these columns the zero_symbol.
+    # Look in `x$meta_data$df_stats` for the counts
+  }
+
+  tbl
 }

--- a/man/tbl_adverse_events.Rd
+++ b/man/tbl_adverse_events.Rd
@@ -7,12 +7,12 @@
 tbl_adverse_events(
   data,
   id,
-  adverse_event,
-  soc,
-  grade,
-  strata,
+  ae,
+  soc = NULL,
+  by = NULL,
+  strata = NULL,
   statistic = "{n} ({p})",
-  header = "**Grade {level}**"
+  header = "**{level}**"
 )
 }
 \arguments{
@@ -20,11 +20,11 @@ tbl_adverse_events(
 
 \item{id}{Variable name of the patient ID}
 
-\item{adverse_event}{Variable name of the adverse event column}
+\item{ae}{Variable name of the adverse event column}
 
 \item{soc}{Variable name of the system organ class column}
 
-\item{grade}{Variable to split results by, e.g. report AEs by grade}
+\item{by}{Variable to split results by, e.g. report AEs by grade}
 
 \item{strata}{Variable to stratify results by, e.g. report AEs summaries
 by treatment group}
@@ -33,7 +33,7 @@ by treatment group}
 The default is \code{"{n} ({p})"}}
 
 \item{header}{String indicating the header to be placed in the table.
-Default is \code{"**Grade {level}**"}}
+Default is \code{"**{level}**"}}
 }
 \description{
 Tabulate Adverse Events

--- a/man/tbl_adverse_events.Rd
+++ b/man/tbl_adverse_events.Rd
@@ -42,10 +42,11 @@ Tabulate Adverse Events
 df_adverse_events \%>\%
   tbl_adverse_events(
     id = patient_id,
-    adverse_event = adverse_event,
+    ae = adverse_event,
     soc = system_organ_class,
-    grade = grade,
-    strata = trt
+    by = grade,
+    strata = trt,
+    header = "**Grade {level}**"
   ) \%>\%
   as_kable() # UPDATE THIS WITH PROPER gt image at some point..
 }

--- a/man/tbl_adverse_events.Rd
+++ b/man/tbl_adverse_events.Rd
@@ -36,9 +36,17 @@ The default is \code{"{n} ({p})"}}
 Default is \code{"**{level}**"}}
 }
 \description{
-Tabulate Adverse Events
+The function tabulates adverse events. One AE per ID will be counted in the
+resulting table. If a \verb{by=} variable is passed and a
+patient experienced more than one of the same AE, the AE associated with the
+highest \verb{by=} level will be included. For example, if a patient has two of
+the same AE and \code{by = grade}, the AE with the highest grade will be
+included.
+Similarly, if tabulations within system organ class are requested, the
+AE within SOC associated with the highest grade will be tabulated.
 }
 \examples{
+# Example 1 -----------------------------------------------------------------
 df_adverse_events \%>\%
   tbl_adverse_events(
     id = patient_id,
@@ -48,5 +56,15 @@ df_adverse_events \%>\%
     strata = trt,
     header = "**Grade {level}**"
   ) \%>\%
-  as_kable() # UPDATE THIS WITH PROPER gt image at some point..
+  as_kable() # UPDATE THIS WITH PROPER gt image at some point.
+
+# Example 2 -----------------------------------------------------------------
+df_adverse_events \%>\%
+  tbl_adverse_events(
+    id = patient_id,
+    ae = adverse_event,
+    by = grade,
+    header = "**Grade {level}**"
+  ) \%>\%
+  as_kable() # UPDATE THIS WITH PROPER gt image at some point.
 }

--- a/tests/testthat/test-tbl_adverse_events.R
+++ b/tests/testthat/test-tbl_adverse_events.R
@@ -3,10 +3,40 @@ test_that("df_adverse_events() works", {
     df_adverse_events %>%
       tbl_adverse_events(
         id = patient_id,
-        adverse_event = adverse_event,
+        ae = adverse_event,
         soc = system_organ_class,
-        grade = grade,
+        by = grade,
         strata = trt
+      ),
+    NA
+  )
+
+  expect_error(
+    df_adverse_events %>%
+      tbl_adverse_events(
+        id = patient_id,
+        ae = adverse_event,
+        soc = system_organ_class,
+        by = grade
+      ),
+    NA
+  )
+
+  expect_error(
+    df_adverse_events %>%
+      tbl_adverse_events(
+        id = patient_id,
+        ae = adverse_event,
+        by = grade
+      ),
+    NA
+  )
+
+  expect_error(
+    df_adverse_events %>%
+      tbl_adverse_events(
+        id = patient_id,
+        ae = adverse_event
       ),
     NA
   )


### PR DESCRIPTION
The updated `tbl_adverse_events()` uses `.complete_ae_data()` to prepare the data. The `soc=`, `by=`, and `strata=` arguments are now all optional. There are many more features to implement, but I think this version provides us a good base that works. We can then merge patches in to add various features. I'll add issues for the features that still need to be implemented.

closes #12
closes #9
closes #6
Added tabulating description to `tbl_adverse_events()` help file addressing #10 . But more detail will be useful, likely. 