### PR TITLE
Added PR Template, `NEWS.md`,  and dev site

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 Checklist for PR reviewer
 
 - [ ] Ensure all package dependencies are installed by running `renv::install()`
-- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
+- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
 - [ ] If a new function was added, function included in `_pkgdown.yml`
 - [ ] If a bug was fixed, a unit test was added for the bug check
 - [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 
 Checklist for PR reviewer
 
+- [ ] Ensure all package dependencies are installed by running `renv::install()`
 - [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
 - [ ] If a new function was added, function included in `_pkgdown.yml`
 - [ ] If a bug was fixed, a unit test was added for the bug check

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+**What changes are proposed in this pull request?**
+
+
+**If there is an GitHub issue associated with this pull request, please provide link.**
+
+
+--------------------------------------------------------------------------------
+
+Checklist for PR reviewer
+
+- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
+- [ ] If a new function was added, function included in `_pkgdown.yml`
+- [ ] If a bug was fixed, a unit test was added for the bug check
+- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
+- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
+- [ ] R CMD Check runs without errors, warnings, and notes
+- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
+- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
+- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
+- [ ] Approve Pull Request
+- [ ] Merge the PR. Please use "Squash and merge".

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# gtreg 0.0.0.9000
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,10 +9,9 @@ authors:
   Daniel D. Sjoberg:
     href: "https://www.danieldsjoberg.com/"
 
-# TODO: add this back after the first release
-# development:
-#   mode: auto
-#   version_label: default
+development:
+  mode: auto
+  version_label: default
 
 navbar:
   structure:


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added a PR template (seen here)
* Added a `NEWS.md` file to track all changes (post first release)
* Added ` pkgdown dev site. From now on, all dev versions will be served at https://shannonpileggi.github.io/gtreg/dev . Dev versions are any versions that include the 9000 extension in the version number. The main site will only be the released version (versions without the 9000 extension).

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #56 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".