### PR TITLE
Adding error when `tbl_ae_focus(include=)` has NA values

### DIFF
--- a/R/tbl_ae_count.R
+++ b/R/tbl_ae_count.R
@@ -84,8 +84,11 @@ tbl_ae_count <- function(data,
     mutate(..ae.. = TRUE, ..soc.. = TRUE) %>%
     group_by(across(any_of("soc")))
 
-  # moving missing by level to end if requested
-  if (missing_location %in% "last" && missing_text %in% levels(data[["by"]])) {
+  # moving missing by level as requested
+  if (missing_location %in% "first" && missing_text %in% levels(data[["by"]])) {
+    data[["by"]] <- forcats::fct_relevel(data[["by"]], missing_text, after = 0L)
+  }
+  else if (missing_location %in% "last" && missing_text %in% levels(data[["by"]])) {
     data[["by"]] <- forcats::fct_relevel(data[["by"]], missing_text, after = Inf)
   }
 
@@ -106,7 +109,8 @@ tbl_ae_count <- function(data,
                    remove_header_row = FALSE,
                    zero_symbol = zero_symbol,
                    labels = names(lst_data),
-                   digits = digits)
+                   digits = digits,
+                   missing_location = missing_location)
   }
 
   # tabulate AEs ---------------------------------------------------------------
@@ -119,7 +123,8 @@ tbl_ae_count <- function(data,
                  zero_symbol = zero_symbol,
                  labels = NULL,
                  digits = digits,
-                 sort = sort)
+                 sort = sort,
+                 missing_location = missing_location)
 
   # stacking tbls into big final AE table --------------------------------------
   if (is.null(soc)) tbl_final <- .stack_soc_ae_tbls(lst_tbl_ae)

--- a/R/tbl_ae_focus.R
+++ b/R/tbl_ae_focus.R
@@ -80,7 +80,11 @@ tbl_ae_focus <- function(data,
   purrr::walk(
     include,
     ~switch(!is.logical(data[[.x]]),
-            stop("Columns indicated in `include=` must be class 'logical'.")))
+            stop("Columns indicated in `include=` must be class 'logical'.", call. = FALSE)))
+  purrr::walk(
+    include,
+    ~switch(any(is.na(data[[.x]])),
+            stop("Columns indicated in `include=` cannot be NA.", call. = FALSE)))
 
   # will return inputs ---------------------------------------------------------
   tbl_ae_focus_inputs <- as.list(environment())

--- a/tests/testthat/test-tbl_ae_count.R
+++ b/tests/testthat/test-tbl_ae_count.R
@@ -84,4 +84,63 @@ test_that("tbl_ae_count() works", {
         missing_location = "NOPE"
       )
   )
+
+  dat <- tibble::tribble(
+    ~subject, ~visit,  ~soc, ~ae, ~grade,
+    # Subject 1 ----------------------------------------------------------------
+    "001", 1, "Eye disorders", "Eye irritation", 1,
+    "001", 1, "Gastrointestinal disorders", "Difficult digestion", 1,
+    "001", 2, "Eye disorders", "Eye irritation", 1,
+    "001", 3, "Eye disorders", "Eye irritation", 2,
+    "001", 4, "Eye disorders", "Vision blurred", 2,
+    # Subject 2 ----------------------------------------------------------------
+    "002", 1, "Gastrointestinal disorders", "Difficult digestion", 2,
+    "002", 1, "Gastrointestinal disorders", "Reflux", 2,
+    "002", 2, "Eye disorders", "Vision blurred", 2,
+    "002", 2, "Gastrointestinal disorders", "Reflux", 2,
+    "002", 3, "Gastrointestinal disorders", "Reflux", NA
+  )
+
+  expect_equal(
+    dat %>%
+      tbl_ae(
+        id = subject,
+        ae = ae,
+        soc = soc,
+        by = grade,
+        missing_location = "hide"
+      ) %>%
+      as_tibble() %>%
+      names(),
+    c("**Adverse Event**", "**1**", "**2**")
+  )
+
+  expect_equal(
+    dat %>%
+      tbl_ae(
+        id = subject,
+        ae = ae,
+        soc = soc,
+        by = grade,
+        missing_location = "first"
+      ) %>%
+      as_tibble() %>%
+      names(),
+    c("**Adverse Event**", "**Unknown**", "**1**", "**2**")
+  )
+
+  expect_equal(
+    dat %>%
+      tbl_ae(
+        id = subject,
+        ae = ae,
+        soc = soc,
+        by = grade,
+        missing_location = "last"
+      ) %>%
+      as_tibble() %>%
+      names(),
+    c("**Adverse Event**", "**1**", "**2**", "**Unknown**")
+  )
+
 })

--- a/tests/testthat/test-tbl_ae_count.R
+++ b/tests/testthat/test-tbl_ae_count.R
@@ -103,8 +103,7 @@ test_that("tbl_ae_count() works", {
 
   expect_equal(
     dat %>%
-      tbl_ae(
-        id = subject,
+      tbl_ae_count(
         ae = ae,
         soc = soc,
         by = grade,
@@ -117,8 +116,7 @@ test_that("tbl_ae_count() works", {
 
   expect_equal(
     dat %>%
-      tbl_ae(
-        id = subject,
+      tbl_ae_count(
         ae = ae,
         soc = soc,
         by = grade,
@@ -131,8 +129,7 @@ test_that("tbl_ae_count() works", {
 
   expect_equal(
     dat %>%
-      tbl_ae(
-        id = subject,
+      tbl_ae_count(
         ae = ae,
         soc = soc,
         by = grade,

--- a/tests/testthat/test-tbl_ae_focus.R
+++ b/tests/testthat/test-tbl_ae_focus.R
@@ -94,4 +94,18 @@ test_that("tbl_ae_focus() works", {
       soc = system_organ_class
     )
   )
+
+  # include vars cannot be NA
+  expect_error(
+    df_adverse_events %>%
+      dplyr::mutate(
+        any_complication = ifelse(dplyr::row_number() == 1L, NA, any_complication)
+      ) %>%
+      tbl_ae_focus(
+        id = patient_id,
+        include = c(any_complication, grade3_complication),
+        ae = adverse_event,
+        soc = system_organ_class
+      )
+  )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Added error messaging when a variable in `tbl_ae_focus(include=)` has NA values. (#110)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #110 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
