### PR TITLE
default spanning header w/ N even when strata not specified

### DIFF
--- a/R/tbl_ae.R
+++ b/R/tbl_ae.R
@@ -181,6 +181,6 @@ tbl_ae <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**, N = {n}"),
-      TRUE ~ .
+      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
     )
 }

--- a/R/tbl_ae.R
+++ b/R/tbl_ae.R
@@ -181,6 +181,6 @@ tbl_ae <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**, N = {n}"),
-      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
+      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**N = {n}**")
     )
 }

--- a/R/tbl_ae_count.R
+++ b/R/tbl_ae_count.R
@@ -143,6 +143,6 @@ tbl_ae_count <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**"),
-      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
+      TRUE ~ .
     )
 }

--- a/R/tbl_ae_count.R
+++ b/R/tbl_ae_count.R
@@ -143,6 +143,6 @@ tbl_ae_count <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**"),
-      TRUE ~ .
+      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
     )
 }

--- a/R/tbl_ae_focus.R
+++ b/R/tbl_ae_focus.R
@@ -236,7 +236,7 @@ tbl_ae_focus <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**, N = {n}"),
-      TRUE ~ .
+      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
     )
 }
 

--- a/R/tbl_ae_focus.R
+++ b/R/tbl_ae_focus.R
@@ -236,7 +236,7 @@ tbl_ae_focus <- function(data,
     purrr::when(
       !is.null(strata) ~
         modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**{strata}**, N = {n}"),
-      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "N = {n}")
+      TRUE ~ modify_ae_spanning_header(., gtsummary::all_stat_cols() ~ "**N = {n}**")
     )
 }
 

--- a/tests/testthat/test-tbl_ae.R
+++ b/tests/testthat/test-tbl_ae.R
@@ -378,6 +378,27 @@ test_that("tbl_ae() works", {
 
 test_that("tbl_ae() headers", {
 
+  # spanning header without strata ---------------------------------------------
+  tbl_no_strata <- df_adverse_events %>%
+    tbl_ae(
+      id = patient_id,
+      ae = adverse_event,
+      by = grade
+    )
+
+  expect_equal(
+    tbl_no_strata$table_styling$header %>% dplyr::filter(!hide),
+    tibble::tribble(
+      ~column, ~hide,   ~align, ~interpret_label,              ~label, ~interpret_spanning_header, ~spanning_header,
+      "label", FALSE,   "left",         "gt::md", "**Adverse Event**",                   "gt::md",               NA,
+      "stat_1", FALSE, "center",         "gt::md",             "**1**",                   "gt::md",         "N = 10",
+      "stat_2", FALSE, "center",         "gt::md",             "**2**",                   "gt::md",         "N = 10",
+      "stat_3", FALSE, "center",         "gt::md",             "**3**",                   "gt::md",         "N = 10",
+      "stat_4", FALSE, "center",         "gt::md",             "**4**",                   "gt::md",         "N = 10",
+      "stat_5", FALSE, "center",         "gt::md",             "**5**",                   "gt::md",         "N = 10"
+    )
+  )
+
   # header_by modified ---------------------------------------------------------
   h_by1 <- c("**Grade 1**", "**Grade 2**", "**Grade 3**","**Grade 4**", "**Grade 5**", "**Overall**")
   tbl_by1 <-

--- a/tests/testthat/test-tbl_ae.R
+++ b/tests/testthat/test-tbl_ae.R
@@ -391,11 +391,11 @@ test_that("tbl_ae() headers", {
     tibble::tribble(
       ~column, ~hide,   ~align, ~interpret_label,              ~label, ~interpret_spanning_header, ~spanning_header,
       "label", FALSE,   "left",         "gt::md", "**Adverse Event**",                   "gt::md",               NA,
-      "stat_1", FALSE, "center",         "gt::md",             "**1**",                   "gt::md",         "N = 10",
-      "stat_2", FALSE, "center",         "gt::md",             "**2**",                   "gt::md",         "N = 10",
-      "stat_3", FALSE, "center",         "gt::md",             "**3**",                   "gt::md",         "N = 10",
-      "stat_4", FALSE, "center",         "gt::md",             "**4**",                   "gt::md",         "N = 10",
-      "stat_5", FALSE, "center",         "gt::md",             "**5**",                   "gt::md",         "N = 10"
+      "stat_1", FALSE, "center",         "gt::md",             "**1**",                   "gt::md",         "**N = 10**",
+      "stat_2", FALSE, "center",         "gt::md",             "**2**",                   "gt::md",         "**N = 10**",
+      "stat_3", FALSE, "center",         "gt::md",             "**3**",                   "gt::md",         "**N = 10**",
+      "stat_4", FALSE, "center",         "gt::md",             "**4**",                   "gt::md",         "**N = 10**",
+      "stat_5", FALSE, "center",         "gt::md",             "**5**",                   "gt::md",         "**N = 10**"
     )
   )
 

--- a/tests/testthat/test-tbl_ae_focus.R
+++ b/tests/testthat/test-tbl_ae_focus.R
@@ -94,4 +94,46 @@ test_that("tbl_ae_focus() works", {
       soc = system_organ_class
     )
   )
+
+  # spanning header without strata ---------------------------------------------
+  tbl_no_strata <- df_adverse_events %>%
+    tbl_ae_focus(
+      id = patient_id,
+      include = c(any_complication, grade3_complication),
+      ae = adverse_event
+    )
+
+  expect_equal(
+    tbl_no_strata$table_styling$header %>% dplyr::filter(!hide),
+    tibble::tribble(
+      ~column, ~hide,   ~align, ~interpret_label,                       ~label, ~interpret_spanning_header, ~spanning_header,
+      "label", FALSE,   "left",         "gt::md",          "**Adverse Event**",                   "gt::md",               NA,
+      "stat_1_1", FALSE, "center",         "gt::md", "**Any Grade Complication**",                   "gt::md",         "N = 10",
+      "stat_1_2", FALSE, "center",         "gt::md",  "**Grade 3+ Complication**",                   "gt::md",         "N = 10"
+    )
+  )
+
+
+  # spanning header with strata ---------------------------------------------
+  tbl_w_strata <- df_adverse_events %>%
+    tbl_ae_focus(
+      id = patient_id,
+      strata = trt,
+      include = c(any_complication, grade3_complication),
+      ae = adverse_event
+    )
+
+  expect_equal(
+    tbl_w_strata$table_styling$header %>% dplyr::filter(!hide),
+    tibble::tribble(
+      ~column, ~hide,   ~align, ~interpret_label,                       ~label, ~interpret_spanning_header,    ~spanning_header,
+      "label", FALSE,   "left",         "gt::md",          "**Adverse Event**",                   "gt::md",                  NA,
+      "stat_1_1_1", FALSE, "center",         "gt::md", "**Any Grade Complication**",                   "gt::md", "**Drug A**, N = 3",
+      "stat_1_1_2", FALSE, "center",         "gt::md",  "**Grade 3+ Complication**",                   "gt::md", "**Drug A**, N = 3",
+      "stat_1_2_1", FALSE, "center",         "gt::md", "**Any Grade Complication**",                   "gt::md", "**Drug B**, N = 7",
+      "stat_1_2_2", FALSE, "center",         "gt::md",  "**Grade 3+ Complication**",                   "gt::md", "**Drug B**, N = 7"
+    )
+  )
+
+
 })

--- a/tests/testthat/test-tbl_ae_focus.R
+++ b/tests/testthat/test-tbl_ae_focus.R
@@ -108,8 +108,8 @@ test_that("tbl_ae_focus() works", {
     tibble::tribble(
       ~column, ~hide,   ~align, ~interpret_label,                       ~label, ~interpret_spanning_header, ~spanning_header,
       "label", FALSE,   "left",         "gt::md",          "**Adverse Event**",                   "gt::md",               NA,
-      "stat_1_1", FALSE, "center",         "gt::md", "**Any Grade Complication**",                   "gt::md",         "N = 10",
-      "stat_1_2", FALSE, "center",         "gt::md",  "**Grade 3+ Complication**",                   "gt::md",         "N = 10"
+      "stat_1_1", FALSE, "center",         "gt::md", "**Any Grade Complication**",                "gt::md",         "**N = 10**",
+      "stat_1_2", FALSE, "center",         "gt::md",  "**Grade 3+ Complication**",                "gt::md",         "**N = 10**"
     )
   )
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
1. Change default spanning header to include N even when strata not specified
-  in both `tbl_ae()` and `tbl_ae_focus()`
-  but not `tbl_ae_count()`
Is this what we want?

2. Added tests to confirm new functionality.

**If there is an GitHub issue associated with this pull request, please provide link.**

Closes #103 
--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
