### PR TITLE
Fix for `by_values=` in `add_overall()`

### DIFF
--- a/R/add_overall.R
+++ b/R/add_overall.R
@@ -128,7 +128,7 @@ add_overall.tbl_ae <- function(x, across = NULL, ...) {
   if (across %in% "both") {
     # table without by variable
     tbl_args_by <- tbl_args
-    tbl_args_by$by <- NULL
+    tbl_args_by$by <- tbl_args_by$by_values <- NULL
     tbl_overall_by <- do.call(class(x)[1], tbl_args_by)
     tbl_overall_by$header_info$overall <- TRUE
 
@@ -145,7 +145,7 @@ add_overall.tbl_ae <- function(x, across = NULL, ...) {
     tbl_args_neither$data[[tbl_args_neither$strata]] <- "Overall"
     if (!is.null(tbl_args_neither$id_df))
       tbl_args_neither$id_df[[tbl_args_neither$strata]] <- "Overall"
-    tbl_args_neither$by <- NULL
+    tbl_args_neither$by <- tbl_args_neither$by_values <- NULL
 
     tbl_overall_neither <- do.call(class(x)[1], tbl_args_neither)
     tbl_overall_neither$header_info$overall <- TRUE
@@ -155,12 +155,12 @@ add_overall.tbl_ae <- function(x, across = NULL, ...) {
       .tbl_ae_merge(tab_spanner = FALSE)
   }
   else if (across %in% "overall-only") {
-    tbl_args$by <- tbl_args$strata <- NULL
+    tbl_args$by <- tbl_args$by_values <- tbl_args$strata <- NULL
     tbl_overall <- do.call(class(x)[1], tbl_args)
     tbl_overall$header_info$overall <- TRUE
   }
   else if (across %in% "by") {
-    tbl_args$by <- NULL
+    tbl_args$by <- tbl_args$by_values <- NULL
     tbl_overall <- do.call(class(x)[1], tbl_args)
     tbl_overall$header_info$overall <- TRUE
   }

--- a/tests/testthat/test-add_overall.R
+++ b/tests/testthat/test-add_overall.R
@@ -138,6 +138,23 @@ test_that("add_overall() warns", {
 
 })
 
+test_that("no errors eith `by_values=`", {
+  tbl <-
+    df_adverse_events %>%
+    tbl_ae(
+      id = patient_id,
+      ae = adverse_event,
+      soc = system_organ_class,
+      by = grade,
+      by_values = as.character(0:5),
+      strata = trt
+    )
+
+  expect_error(add_overall(tbl, across = "both"), NA)
+  expect_error(add_overall(tbl, across = "by"), NA)
+  expect_error(add_overall(tbl, across = "overall-only"), NA)
+})
+
 test_that("add_overall(missing_location=) works", {
   expect_error(
     tbl <-


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Setting `by_values = NULL` when `add_overall()` sets `by = NULL` to avoid errors when `by_values=` is set in the original AE table call.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #122

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
