### PR TITLE
messaging update in `tbl_reg_summary()`

### DIFF
--- a/R/tbl_reg_summary.R
+++ b/R/tbl_reg_summary.R
@@ -46,7 +46,20 @@ tbl_reg_summary <- function(data,
                             include = everything()) {
   missing <- match.arg(missing)
 
-  # execute `tbl_summary()` code with gtreg theme/defaults
+  # check the user has not set any gtsummary theme elements that will be ignored
+  gtsummary::get_gtsummary_theme() %>%
+    purrr::iwalk(function(.x,.y) {
+      if (.y %in% names(gtreg_theme) && !identical(.x, gtreg_theme[[.y]])) {
+        paste("Theme element {.val {.y}} is utilized internally",
+              "by {.code tbl_reg_summary()} and cannot be modified.") %>%
+          cli::cli_alert_warning()
+        paste("Use {.code gtsummary::tbl_summary()} if you",
+              "wish to modify this theme element.") %>%
+          cli::cli_alert_info()
+      }
+    })
+
+  # execute `tbl_summary()` code with gtreg theme/defaults ---------------------
   gtsummary::with_gtsummary_theme(
     x = gtreg_theme,
     expr =
@@ -59,11 +72,10 @@ tbl_reg_summary <- function(data,
   )
 }
 
-# creating theme for gtreg summaries
+# creating theme for gtreg summaries -------------------------------------------
 gtreg_theme <-
   list(
     "tbl_summary-str:default_con_type" = "continuous2",
     "tbl_summary-str:continuous_stat" =
-      c("{N_nonmiss}", "{mean} ({sd})", "{median} ({p25}, {p75})", "{min}, {max}", "{N_miss}"),
-    "tbl_summary-fn:percent_fun" = function(x) style_percent(x, digits = 1)
+      c("{N_nonmiss}", "{mean} ({sd})", "{median} ({p25}, {p75})", "{min}, {max}", "{N_miss}")
   )

--- a/tests/testthat/test-tbl_reg_summary.R
+++ b/tests/testthat/test-tbl_reg_summary.R
@@ -5,4 +5,10 @@ test_that("tbl_reg_summary works", {
     NA
   )
 
+  gtsummary::set_gtsummary_theme(list("tbl_summary-str:default_con_type" = "continuous"))
+  expect_message(
+    df_patient_characteristics %>%
+      tbl_reg_summary(by = trt, include = c(marker, status))
+  )
+  gtsummary::reset_gtsummary_theme()
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Added a message to users who may have a gsummary theme element in place that would be ignored by `tbl_reg_summary()`. (#131)
- Also switched back to the default rounding for percentages.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #131

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
