### PR TITLE
Bug fix for fct grouping variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/man/tbl_listing.Rd
+++ b/man/tbl_listing.Rd
@@ -11,12 +11,7 @@ tbl_listing(data, group_by = NULL, bold_headers = TRUE)
 
 \item{group_by}{Single variable name indicating a grouping variable.
 Default is \code{NULL} for no grouping variable. When specified, a grouping
-row will be added to the first column. The grouping column and the first
-column in the table will be combined and the type/class may be converted
-to common type/class for both columns.
-
-When the \code{group_by} argument is utilized, groups are ordered accrording to the grouping
-variable's type (i.e.,  character, numeric, or factor).}
+row will be added to the first column. See details below.}
 
 \item{bold_headers}{logical indicating whether to bold column headers.
 Default is \code{TRUE}}
@@ -29,6 +24,18 @@ Function creates a gtsummary-class listing of data. Column labels are
 used as column headers, when present.
 The listing prints observations in the order of the input data.
 }
+\section{group_by}{
+
+
+The grouping column and the first column in the table will be combined
+and the type/class may be converted to common type/class for both columns.
+However, if either the \verb{group_by=} column or the first column are factors,
+the factor column(s) will first be converted to character.
+
+The groups are ordered according to the grouping
+variable's type (i.e.,  character, numeric, or factor).
+}
+
 \section{Example Output}{
 
 \if{html}{Example 1}

--- a/tests/testthat/test-tbl_listing.R
+++ b/tests/testthat/test-tbl_listing.R
@@ -68,4 +68,44 @@ test_that("tbl_listing(group_by=) works with various column types", {
   )
   expect_equal(tbl$adverse_event[1:3] %>% as.character(),
                c("Gastrointestinal disorders", "Intestinal dilatation", "Intestinal dilatation"))
+
+  expect_error(
+    tbl <-
+      head(mtcars, n = 3) %>%
+      tibble::as_tibble() %>%
+      dplyr::mutate(cyl = factor(cyl)) %>%
+      tbl_listing(group_by = "cyl"),
+    NA
+  )
+  expect_equal(
+    as_tibble(tbl, col_labels = FALSE)[["mpg"]],
+    c("4", "22.8", "6", "21", "21")
+  )
+
+  expect_error(
+    tbl <-
+      head(mtcars, n = 3) %>%
+      tibble::as_tibble() %>%
+      dplyr::mutate(mpg = factor(mpg)) %>%
+      tbl_listing(group_by = "mpg"),
+    NA
+  )
+  expect_equal(
+    as_tibble(tbl, col_labels = FALSE)[["cyl"]],
+    c("21",   "6" ,   "6"   , "22.8", "4" )
+  )
+
+  expect_error(
+    tbl <-
+      head(mtcars, n = 3) %>%
+      tibble::as_tibble() %>%
+      dplyr::mutate(mpg = factor(mpg),
+                    cyl = factor(cyl)) %>%
+      tbl_listing(group_by = "cyl"),
+    NA
+  )
+  expect_equal(
+    as_tibble(tbl, col_labels = FALSE)[["mpg"]],
+    c("4", "22.8", "6", "21", "21")
+  )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Fix in `tbl_listing()` when the grouping variable or the first column are factor. The `rbind()` function cannot stack a factor and numeric variable. In that case, the numeric variable was being coerced to NA. Now when either of these columns are factor, they are converted to character prior to inserting the grouping rows.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #135

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] Ensure all package dependencies are installed by running `renv::install()`
- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
