### PR TITLE
Fix for sparse data in `tbl_ae_count()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtreg
 Title: Regulatory Tables for Clinical Research
-Version: 0.1.0.9001
+Version: 0.1.0.9002
 Authors@R: c(
     person("Shannon", "Pileggi", , "shannon.pileggi@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-7732-4164")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtreg (development version)
 
+* Fix in `tbl_ae_count()` when individual stratum had complete unobserved data for the SOC and AE. (#165)
+
 * Fix in the denominator of `tbl_ae_focus()` for the system organ class level. (#163)
 
 # gtreg 0.1.0

--- a/tests/testthat/test-tbl_ae_count.R
+++ b/tests/testthat/test-tbl_ae_count.R
@@ -16,6 +16,23 @@ dat <- tibble::tribble(
   "002", 3, "Gastrointestinal disorders", "Reflux", NA
 )
 
+dat_unobserved_stratum <-
+  tibble::tribble(
+    ~id, ~cohort,                                                   ~soc,                                    ~pt, ~valxx,
+    1,      "C1", "General disorders and administration site conditions",                              "Fatigue",    "1",
+    1,      "C1",                                   "Vascular disorders",                            "Hot flush",    "1",
+    1,      "C1",                                       "Investigations",                     "Weight increased",    "2",
+    3,      "C2",                                       "Investigations",   "Alanine aminotransferase increased",    "1",
+    3,      "C2",                                       "Investigations", "Aspartate aminotransferase increased",    "1",
+    3,      "C2",                             "Nervous system disorders",                   "Cognitive disorder",    "1",
+    16,     "C3",      "Musculoskeletal and connective tissue disorders",                           "Arthralgia",    "1",
+    16,     "C3",                             "Nervous system disorders",                   "Cognitive disorder",    "1",
+    16,     "C3", "General disorders and administration site conditions",                              "Fatigue",    "1",
+    6,      "C4",                           "Gastrointestinal disorders",                            "Diarrhoea",    "2",
+    6,      "C4",                             "Nervous system disorders",                            "Dysgeusia",    "1",
+    6,      "C4",                                   "Vascular disorders",                            "Hot flush",    "1"
+  )
+
 test_that("tbl_ae_count() works", {
   expect_error(
     tbl1 <-
@@ -189,4 +206,41 @@ test_that("tbl_ae_count() works", {
       ),
     NA
   )
+})
+
+test_that("tbl_ae_count() works with unobserved data in stratum", {
+  expect_error(
+    tbl_unobserved_stratum <-
+      dat_unobserved_stratum %>%
+      tbl_ae_count(
+        ae = pt,
+        soc = soc,
+        by = valxx,
+        strata = cohort
+      ),
+    NA
+  )
+
+  # UPDATE THIS CODE TO PERFORM CHECKS THAT THE COUNTS ARE CORRECT
+  # df_count_checks_ae <-
+  #   dat_unobserved_stratum %>%
+  #   mutate(strata = paste(cohort, valxx)) %>%
+  #   dplyr::mutate(across(c(soc, pt), factor)) %>%
+  #   dplyr::count(soc, pt, strata) %>%
+  #   arrange(strata) %>%
+  #   tidyr::pivot_wider(id_cols = c(soc, pt), names_from = strata, values_from = n) %>%
+  #   arrange(soc, pt)
+  # df_count_checks_ae
+  #
+  # dat_unobserved_stratum %>%
+  #   mutate(strata = paste(cohort, valxx)) %>%
+  #   dplyr::count(soc, strata) %>%
+  #   arrange(strata) %>%
+  #   tidyr::pivot_wider(id_cols = c(soc), names_from = strata, values_from = n)  %>%
+  #   arrange(soc)
+  #
+  # tbl_unobserved_stratum %>%
+  #   gtsummary::modify_column_unhide(variable) %>%
+  #   as_tibble()
+
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Fix in `tbl_ae_count()` when individual stratum had complete unobserved data for the SOC and AE. (#165)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #165

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] Ensure all package dependencies are installed by running `renv::install()`
- [x] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] Has `NEWS.md` been updated with the changes from this pull request under the heading "`# gtreg (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".
